### PR TITLE
make linkTo variable in Linkable interface

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 kotlin.code.style=official
 
-release_version = 1.1.1
+release_version = 1.2.0
 description = 'java beans for th2 custom resources'
 
 kotlin_version=1.6.21

--- a/src/main/kotlin/com/exactpro/th2/model/latest/box/pins/PinSpec.kt
+++ b/src/main/kotlin/com/exactpro/th2/model/latest/box/pins/PinSpec.kt
@@ -32,7 +32,7 @@ sealed interface MqPin : Pin {
 }
 
 sealed interface Linkable : Pin {
-    val linkTo: List<LinkEndpoint>?
+    var linkTo: List<LinkEndpoint>?
 }
 
 data class MqSubscriber(


### PR DESCRIPTION
Exposing a setter in `Linkable` type. Its usage should be constrained to as small of a scope as possible; copying is encouraged.